### PR TITLE
Use Class.new instead of Type.createInstance() for animation states

### DIFF
--- a/away3d/animators/AnimatorBase.hx
+++ b/away3d/animators/AnimatorBase.hx
@@ -1,7 +1,6 @@
 package away3d.animators;
 
 import away3d.animators.nodes.AnimationNodeBase;
-import away3d.animators.states.AnimationStateBase;
 import away3d.animators.states.IAnimationState;
 import away3d.entities.Mesh;
 import away3d.events.AnimatorEvent;
@@ -42,7 +41,7 @@ class AnimatorBase extends NamedAssetBase implements IAsset
 	private var _activeState:IAnimationState;
 	private var _activeAnimationName:String;
 	private var _absoluteTime:Int = 0;
-	private var _animationStates:Map<AnimationNodeBase, AnimationStateBase> = new Map();
+	private var _animationStates:Map<AnimationNodeBase, IAnimationState> = new Map();
 	
 	/**
 	 * Enables translation of the animated mesh from data returned per frame via the positionDelta property of the active animation node. Defaults to true.
@@ -51,17 +50,17 @@ class AnimatorBase extends NamedAssetBase implements IAsset
 	 */
 	public var updatePosition:Bool = true;
 
-	public function getAnimationState(node:AnimationNodeBase):AnimationStateBase
+	public function getAnimationState(node:AnimationNodeBase):IAnimationState
 	{
 		var className:Class<IAnimationState> = node.stateClass;
 		
 		if (!_animationStates.exists(node))
-			_animationStates.set(node, cast(Type.createInstance(className, [this, node]), AnimationStateBase));
+			_animationStates.set(node, cast(Type.createInstance(className, [this, node]), IAnimationState));
 		
 		return _animationStates.get(node);
 	}
 	
-	public function getAnimationStateByName(name:String):AnimationStateBase
+	public function getAnimationStateByName(name:String):IAnimationState
 	{
 		return getAnimationState(_animationSet.getAnimation(name));
 	}

--- a/away3d/animators/AnimatorBase.hx
+++ b/away3d/animators/AnimatorBase.hx
@@ -52,10 +52,10 @@ class AnimatorBase extends NamedAssetBase implements IAsset
 
 	public function getAnimationState(node:AnimationNodeBase):IAnimationState
 	{
-		var className:Class<IAnimationState> = node.stateClass;
+		var stateConstructor:IAnimator -> AnimationNodeBase -> IAnimationState = node.stateConstructor;
 		
 		if (!_animationStates.exists(node))
-			_animationStates.set(node, cast(Type.createInstance(className, [this, node]), IAnimationState));
+			_animationStates.set(node,stateConstructor(cast(this, IAnimator), node));
 		
 		return _animationStates.get(node);
 	}

--- a/away3d/animators/IAnimator.hx
+++ b/away3d/animators/IAnimator.hx
@@ -50,9 +50,9 @@ interface IAnimator
 	 */
 	function removeOwner(mesh:Mesh):Void;
 	
-	function getAnimationState(node:AnimationNodeBase):AnimationStateBase;
+	function getAnimationState(node:AnimationNodeBase):IAnimationState;
 	
-	function getAnimationStateByName(name:String):AnimationStateBase;
+	function getAnimationStateByName(name:String):IAnimationState;
 	
 	/**
 	 * Returns a shallow clone (re-using the same IAnimationSet) of this IAnimator.

--- a/away3d/animators/nodes/AnimationNodeBase.hx
+++ b/away3d/animators/nodes/AnimationNodeBase.hx
@@ -1,5 +1,6 @@
 package away3d.animators.nodes;
 
+import away3d.animators.AnimatorBase;
 import away3d.animators.states.IAnimationState;
 import away3d.library.assets.*;
 
@@ -8,14 +9,14 @@ import away3d.library.assets.*;
  */
 class AnimationNodeBase extends NamedAssetBase implements IAsset
 {
-	public var stateClass(get, never):Class<IAnimationState>;
+	public var stateConstructor(get, never):IAnimator -> AnimationNodeBase -> IAnimationState;
 	public var assetType(get, never):String;
 	
-	private var _stateClass:Class<IAnimationState>;
+	private var _stateConstructor:IAnimator -> AnimationNodeBase -> IAnimationState;
 	
-	private function get_stateClass():Class<IAnimationState>
+	private function get_stateConstructor():IAnimator -> AnimationNodeBase -> IAnimationState
 	{
-		return _stateClass;
+		return _stateConstructor;
 	}
 	
 	/**

--- a/away3d/animators/nodes/ParticleAccelerationNode.hx
+++ b/away3d/animators/nodes/ParticleAccelerationNode.hx
@@ -37,7 +37,7 @@ class ParticleAccelerationNode extends ParticleNodeBase
 	{
 		super("ParticleAcceleration", mode, 3);
 		
-		_stateClass = ParticleAccelerationState;
+		_stateConstructor = cast ParticleAccelerationState.new;
 		
 		_acceleration = acceleration;
 		if (_acceleration == null)_acceleration = new Vector3D();

--- a/away3d/animators/nodes/ParticleBezierCurveNode.hx
+++ b/away3d/animators/nodes/ParticleBezierCurveNode.hx
@@ -50,7 +50,7 @@ class ParticleBezierCurveNode extends ParticleNodeBase
 	{
 		super("ParticleBezierCurve", mode, 6);
 		
-		_stateClass = ParticleBezierCurveState;
+		_stateConstructor = cast ParticleBezierCurveState.new;
 		
 		_controlPoint = controlPoint;
 		if (_controlPoint == null)

--- a/away3d/animators/nodes/ParticleBillboardNode.hx
+++ b/away3d/animators/nodes/ParticleBillboardNode.hx
@@ -27,7 +27,7 @@ class ParticleBillboardNode extends ParticleNodeBase
 	{
 		super("ParticleBillboard", ParticlePropertiesMode.GLOBAL, 0, 4);
 		
-		_stateClass = ParticleBillboardState;
+		_stateConstructor = cast ParticleBillboardState.new;
 		
 		_billboardAxis = billboardAxis;
 	}

--- a/away3d/animators/nodes/ParticleColorNode.hx
+++ b/away3d/animators/nodes/ParticleColorNode.hx
@@ -82,7 +82,7 @@ class ParticleColorNode extends ParticleNodeBase
 	 */
 	public function new(mode:Int, usesMultiplier:Bool = true, usesOffset:Bool = true, usesCycle:Bool = false, usesPhase:Bool = false, startColor:ColorTransform = null, endColor:ColorTransform = null, cycleDuration:Float = 1, cyclePhase:Float = 0)
 	{
-		_stateClass = ParticleColorState;
+		_stateConstructor = cast ParticleColorState.new;
 		
 		_usesMultiplier = usesMultiplier;
 		_usesOffset = usesOffset;

--- a/away3d/animators/nodes/ParticleFollowNode.hx
+++ b/away3d/animators/nodes/ParticleFollowNode.hx
@@ -36,7 +36,7 @@ class ParticleFollowNode extends ParticleNodeBase
 	 */
 	public function new(usesPosition:Bool = true, usesRotation:Bool = true, smooth:Bool = false)
 	{
-		_stateClass = ParticleFollowState;
+		_stateConstructor = cast ParticleFollowState.new;
 		
 		_usesPosition = usesPosition;
 		_usesRotation = usesRotation;

--- a/away3d/animators/nodes/ParticleInitialColorNode.hx
+++ b/away3d/animators/nodes/ParticleInitialColorNode.hx
@@ -36,7 +36,7 @@ class ParticleInitialColorNode extends ParticleNodeBase
 	
 	public function new(mode:Int, usesMultiplier:Bool = true, usesOffset:Bool = false, initialColor:ColorTransform = null)
 	{
-		_stateClass = ParticleInitialColorState;
+		_stateConstructor = cast ParticleInitialColorState.new;
 		
 		_usesMultiplier = usesMultiplier;
 		_usesOffset = usesOffset;

--- a/away3d/animators/nodes/ParticleOrbitNode.hx
+++ b/away3d/animators/nodes/ParticleOrbitNode.hx
@@ -64,7 +64,7 @@ class ParticleOrbitNode extends ParticleNodeBase
 			len++;
 		super("ParticleOrbit", mode, len);
 		
-		_stateClass = ParticleOrbitState;
+		_stateConstructor = cast ParticleOrbitState.new;
 		
 		_usesEulers = usesEulers;
 		_usesCycle = usesCycle;

--- a/away3d/animators/nodes/ParticleOscillatorNode.hx
+++ b/away3d/animators/nodes/ParticleOscillatorNode.hx
@@ -37,7 +37,7 @@ class ParticleOscillatorNode extends ParticleNodeBase
 	{
 		super("ParticleOscillator", mode, 4);
 		
-		_stateClass = ParticleOscillatorState;
+		_stateConstructor = cast ParticleOscillatorState.new;
 		
 		_oscillator = oscillator;
 		if (_oscillator == null)

--- a/away3d/animators/nodes/ParticlePositionNode.hx
+++ b/away3d/animators/nodes/ParticlePositionNode.hx
@@ -37,7 +37,7 @@ class ParticlePositionNode extends ParticleNodeBase
 	{
 		super("ParticlePosition", mode, 3);
 		
-		_stateClass = ParticlePositionState;
+		_stateConstructor = cast ParticlePositionState.new;
 
 		_position = position;
 		if (_position == null)

--- a/away3d/animators/nodes/ParticleRotateToHeadingNode.hx
+++ b/away3d/animators/nodes/ParticleRotateToHeadingNode.hx
@@ -22,7 +22,7 @@ class ParticleRotateToHeadingNode extends ParticleNodeBase
 	{
 		super("ParticleRotateToHeading", ParticlePropertiesMode.GLOBAL, 0, 3);
 		
-		_stateClass = ParticleRotateToHeadingState;
+		_stateConstructor = cast ParticleRotateToHeadingState.new;
 	}
 	
 	/**

--- a/away3d/animators/nodes/ParticleRotateToPositionNode.hx
+++ b/away3d/animators/nodes/ParticleRotateToPositionNode.hx
@@ -36,7 +36,7 @@ class ParticleRotateToPositionNode extends ParticleNodeBase
 	{
 		super("ParticleRotateToPosition", mode, 3, 3);
 		
-		_stateClass = ParticleRotateToPositionState;
+		_stateConstructor = cast ParticleRotateToPositionState.new;
 		
 		_position = position;
 		if (_position == null)

--- a/away3d/animators/nodes/ParticleRotationalVelocityNode.hx
+++ b/away3d/animators/nodes/ParticleRotationalVelocityNode.hx
@@ -34,7 +34,7 @@ class ParticleRotationalVelocityNode extends ParticleNodeBase
 	 */
 	public function new(mode:Int, rotationalVelocity:Vector3D = null)
 	{
-		_stateClass = ParticleRotationalVelocityState;
+		_stateConstructor = cast ParticleRotationalVelocityState.new;
 		
 		super("ParticleRotationalVelocity", mode, 4);
 		

--- a/away3d/animators/nodes/ParticleScaleNode.hx
+++ b/away3d/animators/nodes/ParticleScaleNode.hx
@@ -59,7 +59,7 @@ class ParticleScaleNode extends ParticleNodeBase
 			len++;
 		super("ParticleScale", mode, len, 3);
 		
-		_stateClass = ParticleScaleState;
+		_stateConstructor = cast ParticleScaleState.new;
 		
 		_usesCycle = usesCycle;
 		_usesPhase = usesPhase;

--- a/away3d/animators/nodes/ParticleSegmentedColorNode.hx
+++ b/away3d/animators/nodes/ParticleSegmentedColorNode.hx
@@ -38,7 +38,7 @@ class ParticleSegmentedColorNode extends ParticleNodeBase
 	
 	public function new(usesMultiplier:Bool, usesOffset:Bool, numSegmentPoint:Int, startColor:ColorTransform, endColor:ColorTransform, segmentPoints:Vector<ColorSegmentPoint>)
 	{
-		_stateClass = ParticleSegmentedColorState;
+		_stateConstructor = cast ParticleSegmentedColorState.new;
 		
 		//because of the stage3d register limitation, it only support the global mode
 		super("ParticleSegmentedColor", ParticlePropertiesMode.GLOBAL, 0, ParticleAnimationSet.COLOR_PRIORITY);

--- a/away3d/animators/nodes/ParticleSegmentedScaleNode.hx
+++ b/away3d/animators/nodes/ParticleSegmentedScaleNode.hx
@@ -32,7 +32,7 @@ class ParticleSegmentedScaleNode extends ParticleNodeBase
 	 */
 	public function new(numSegmentPoint:Int, startScale:Vector3D, endScale:Vector3D, segmentScales:Vector<Vector3D>)
 	{
-		_stateClass = ParticleSegmentedScaleState;
+		_stateConstructor = cast ParticleSegmentedScaleState.new;
 		
 		//because of the stage3d register limitation, it only support the global mode
 		super("ParticleSegmentedScale", ParticlePropertiesMode.GLOBAL, 0, 3);

--- a/away3d/animators/nodes/ParticleSpriteSheetNode.hx
+++ b/away3d/animators/nodes/ParticleSpriteSheetNode.hx
@@ -101,7 +101,7 @@ class ParticleSpriteSheetNode extends ParticleNodeBase
 		}
 		super("ParticleSpriteSheet", mode, len, ParticleAnimationSet.POST_PRIORITY + 1);
 		
-		_stateClass = ParticleSpriteSheetState;
+		_stateConstructor = cast ParticleSpriteSheetState.new;
 		
 		_usesCycle = usesCycle;
 		_usesPhase = usesPhase;

--- a/away3d/animators/nodes/ParticleTimeNode.hx
+++ b/away3d/animators/nodes/ParticleTimeNode.hx
@@ -34,7 +34,7 @@ class ParticleTimeNode extends ParticleNodeBase
 	 */
 	public function new(usesDuration:Bool = false, usesLooping:Bool = false, usesDelay:Bool = false)
 	{
-		_stateClass = ParticleTimeState;
+		_stateConstructor = cast ParticleTimeState.new;
 		
 		_usesDuration = usesDuration;
 		_usesLooping = usesLooping;

--- a/away3d/animators/nodes/ParticleUVNode.hx
+++ b/away3d/animators/nodes/ParticleUVNode.hx
@@ -55,7 +55,7 @@ class ParticleUVNode extends ParticleNodeBase
 	{
 		super("ParticleUV", mode, 4, ParticleAnimationSet.POST_PRIORITY + 1);
 		
-		_stateClass = ParticleUVState;
+		_stateConstructor = cast ParticleUVState.new;
 		
 		_cycle = cycle;
 		_scale = scale;

--- a/away3d/animators/nodes/ParticleVelocityNode.hx
+++ b/away3d/animators/nodes/ParticleVelocityNode.hx
@@ -37,7 +37,7 @@ class ParticleVelocityNode extends ParticleNodeBase
 	{
 		super("ParticleVelocity", mode, 3);
 		
-		_stateClass = ParticleVelocityState;
+		_stateConstructor = cast ParticleVelocityState.new;
 		
 		_velocity = velocity;
 		if (_velocity == null)

--- a/away3d/animators/nodes/SkeletonBinaryLERPNode.hx
+++ b/away3d/animators/nodes/SkeletonBinaryLERPNode.hx
@@ -24,7 +24,7 @@ class SkeletonBinaryLERPNode extends AnimationNodeBase
 	public function new()
 	{
 		super();
-		_stateClass = SkeletonBinaryLERPState;
+		_stateConstructor = cast SkeletonBinaryLERPState.new;
 	}
 	
 	/**

--- a/away3d/animators/nodes/SkeletonClipNode.hx
+++ b/away3d/animators/nodes/SkeletonClipNode.hx
@@ -35,7 +35,7 @@ class SkeletonClipNode extends AnimationClipNodeBase
 	 */
 	public function new()
 	{
-		_stateClass = SkeletonClipState;
+		_stateConstructor = cast SkeletonClipState.new;
 		super();
 	}
 	

--- a/away3d/animators/nodes/SkeletonDifferenceNode.hx
+++ b/away3d/animators/nodes/SkeletonDifferenceNode.hx
@@ -23,7 +23,7 @@ class SkeletonDifferenceNode extends AnimationNodeBase
 	 */
 	public function new()
 	{
-		_stateClass = SkeletonDifferenceState;
+		_stateConstructor = cast SkeletonDifferenceState.new;
 		super();
 	}
 	

--- a/away3d/animators/nodes/SkeletonDirectionalNode.hx
+++ b/away3d/animators/nodes/SkeletonDirectionalNode.hx
@@ -30,7 +30,7 @@ class SkeletonDirectionalNode extends AnimationNodeBase
 	
 	public function new()
 	{
-		_stateClass = SkeletonDirectionalState;
+		_stateConstructor = cast SkeletonDirectionalState.new;
 		super();
 	}
 	

--- a/away3d/animators/nodes/SkeletonNaryLERPNode.hx
+++ b/away3d/animators/nodes/SkeletonNaryLERPNode.hx
@@ -25,7 +25,7 @@ class SkeletonNaryLERPNode extends AnimationNodeBase
 	 */
 	public function new()
 	{
-		_stateClass = SkeletonNaryLERPState;
+		_stateConstructor = cast SkeletonNaryLERPState.new;
 		super();
 	}
 	

--- a/away3d/animators/nodes/SpriteSheetClipNode.hx
+++ b/away3d/animators/nodes/SpriteSheetClipNode.hx
@@ -19,7 +19,7 @@ class SpriteSheetClipNode extends AnimationClipNodeBase
 	 */
 	public function new()
 	{
-		_stateClass = SpriteSheetAnimationState;
+		_stateConstructor = cast SpriteSheetAnimationState.new;
 		super();
 	}
 	

--- a/away3d/animators/nodes/UVClipNode.hx
+++ b/away3d/animators/nodes/UVClipNode.hx
@@ -27,7 +27,7 @@ class UVClipNode extends AnimationClipNodeBase
 	 */
 	public function new()
 	{
-		_stateClass = UVClipState;
+		_stateConstructor = cast UVClipState.new;
 		super();
 	}
 	

--- a/away3d/animators/nodes/VertexClipNode.hx
+++ b/away3d/animators/nodes/VertexClipNode.hx
@@ -29,7 +29,7 @@ class VertexClipNode extends AnimationClipNodeBase
 	 */
 	public function new()
 	{
-		_stateClass = VertexClipState;
+		_stateConstructor = cast VertexClipState.new;
 		super();
 	}
 	

--- a/away3d/animators/transitions/CrossfadeTransitionNode.hx
+++ b/away3d/animators/transitions/CrossfadeTransitionNode.hx
@@ -17,6 +17,6 @@ class CrossfadeTransitionNode extends SkeletonBinaryLERPNode
 	public function new()
 	{
 		super();
-		_stateClass = CrossfadeTransitionState;	
+		_stateConstructor = cast CrossfadeTransitionState.new;	
 	}
 }


### PR DESCRIPTION
This still isn't type-safe (due to casting each instance of `Class.new`), but at least DCE won't break it. I tried not casting `Class.new`, but that would have required rewriting a bunch of other stuff, would still have required casts, and would have reduced type-safety when manually instantiating relevant classes.

Note: this pull request includes requests #15 and #16. To help keep things organized, accept those two first. (Or if you want to implement #16 your own way, I can rewrite this to fit your implementation.)