### PR TITLE
Bug fix: OBJParser overwrites valid material names.

### DIFF
--- a/away3d/loaders/parsers/OBJParser.hx
+++ b/away3d/loaders/parsers/OBJParser.hx
@@ -241,7 +241,7 @@ class OBJParser extends ParserBase
 				createObject(trunk);
 			case "usemtl":
 				if (_mtlLib) {
-					if (trunk[1] != "")
+					if (trunk[1] == "")
 						trunk[1] = "def000";
 					_materialIDs.push(trunk[1]);
 					_activeMaterialID = trunk[1];


### PR DESCRIPTION
...and it fails to overwrite invalid ones. This makes the `usemtl` command useless, because if you specify which material to use, it'll overwrite it.