### PR TITLE
Ensure material names are unique.

### DIFF
--- a/away3d/loaders/parsers/OBJParser.hx
+++ b/away3d/loaders/parsers/OBJParser.hx
@@ -833,7 +833,7 @@ class OBJParser extends ParserBase
 					}
 				}
 				
-				mesh.material.name = decomposeID[1] != "" ? decomposeID[1] : decomposeID[0];
+				mesh.material.name = decomposeID[0] == "def000" ? decomposeID[1] + ".material" : decomposeID[0];
 				_meshes.splice(i, 1);
 				--i;
 			}


### PR DESCRIPTION
Asset3DLibrary indexes meshes and materials based only on their names. If you have a mesh and a material with the same name, one must overwrite the other. This code usually sets the material name to `decomposeID[1]`, even though `decomposeID[1]` is the name of the mesh it's attached to. Instant cache collision.

Not that everything this function acts on gets cached. I haven't dug through the code enough to figure out all the details, I just know that `ColorMaterial`s do end up getting cached, so this matters for them.

Finally, something that applies to every material: if the user picked a name for a material, Away3D should use that name. Replacing the material name with the mesh name is just discarding useful information. If they didn't pick one, that's when it makes sense to use the mesh's name (plus a suffix for uniqueness).