### PR TITLE
Fix SkeletonAnimator parent JointPose is null.

### DIFF
--- a/away3d/animators/SkeletonAnimator.hx
+++ b/away3d/animators/SkeletonAnimator.hx
@@ -504,7 +504,11 @@ class SkeletonAnimator extends AnimatorBase implements IAnimator
 			} else {
 				// append parent pose
 				parentPose = globalPoses[parentIndex];
-				
+				if(parentPose == null)
+				{
+				     parentPose = new JointPose();
+				     globalPoses[parentIndex] = parentPose;
+				}
 				// rotate point
 				or = parentPose.orientation;
 				tr = pose.translation;


### PR DESCRIPTION
Fix SkeletonAnimator parent JointPose is null.

Dae needs to be able to play the animation normally, but still needs to merge @player-03  requests.

And improve DAEAnimation:

```haxe
class DAEAnimation extends DAEElement
{
	public function new(element:Access = null)
	{
		super(element);
                //Fix animate bug.
		if(this.id == "")
			this.id = element.node.channel.att.resolve("source");
	}
}
```