### PR TITLE
Obj fix

### DIFF
--- a/away3d/loaders/parsers/OBJParser.hx
+++ b/away3d/loaders/parsers/OBJParser.hx
@@ -237,9 +237,8 @@ class OBJParser extends ParserBase
 				loadMtl(trunk[1]);
 			case "g":
 				createGroup(trunk);
-			case "o":
-				createObject(trunk);
 			case "usemtl":
+				createObject(trunk);
 				if (_mtlLib) {
 					if (trunk[1] == "")
 						trunk[1] = "def000";


### PR DESCRIPTION
Upon loading a .OBJ file into away 3D, it will only use the last mentioned texture in an object, defined by "o" and "usemtl"

this happens because each object can only have 1 texture, but the OBJ file attempted to load multiple textures onto 1 obj. I fixed this by instead of creating a new object on every use of the O keyword, it ignores the O keyword and will then create a new object under usemtl, then applies the texture.