### PR TITLE
chore: remove obsolete Haxe versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        haxe-version: [3.4.7, 4.0.5, 4.1.5, 4.2.5, 4.3.2]
+        haxe-version: [4.1.5, 4.2.5, 4.3.7]
     steps:
 
       - uses: krdlab/setup-haxe@v1
@@ -106,7 +106,6 @@ jobs:
           haxelib run lime build samples/basic/Tweening3D flash
 
       - name: Build HashLink samples
-        if: ${{ matrix.haxe-version != '3.4.7' }}
         run: |
           haxelib run lime build samples/basic/Particles hl
           haxelib run lime build samples/basic/Tweening3D hl

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        haxe-version: [4.1.5, 4.2.5, 4.3.7]
+        haxe-version: [4.0.5, 4.1.5, 4.2.5, 4.3.7]
     steps:
 
       - uses: krdlab/setup-haxe@v1


### PR DESCRIPTION
I also bumped Haxe 4.3.2 to 4.3.7 as that’s now the latest release but I could revert that back. I don’t expect this to be merged for a few reasons in mind