### PR TITLE
Allow effect methods to modify vertex position.

### DIFF
--- a/away3d/materials/compilation/ShaderCompiler.hx
+++ b/away3d/materials/compilation/ShaderCompiler.hx
@@ -323,8 +323,10 @@ class ShaderCompiler
 		createNormalRegisters();
 		if (_dependencyCounter.globalPosDependencies > 0 || _forceSeperateMVP)
 			compileGlobalPositionCode();
-		compileProjectionCode();
+		if (_dependencyCounter.projectionDependencies > 0)
+			_sharedRegisters.projectionFragment = _registerCache.getFreeVarying();
 		compileMethodsCode();
+		compileProjectionCode();
 		compileFragmentOutput();
 		_fragmentPostLightCode = fragmentCode;
 	}
@@ -465,7 +467,6 @@ class ShaderCompiler
 		var code:String;
 
 		if (_dependencyCounter.projectionDependencies > 0) {
-			_sharedRegisters.projectionFragment = _registerCache.getFreeVarying();
 			code = "m44 vt5, " + pos + ", vc0		\n" +
 				"mov " + _sharedRegisters.projectionFragment + ", vt5\n" +
 				"mov op, vt5\n";


### PR DESCRIPTION
`compileProjectionCode()` finalizes the vertex position, preventing effect methods from adjusting it. There's no good reason to do this, it exclusively removes functionality.

Judging from https://github.com/away3d/away3d-core-fp11/commit/7c8f5ce568dcea6ee616a928b80878245faef7ff, this was done was to set `projectionFragment`, which some methods require. However, this can be set separately.